### PR TITLE
Pre-build less sprites import file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ src/_common/data/config.ts
 # Generated atoms / bundles.ts / pages.ts / Pre-build files
 src/_common/atoms.ts
 src/_common/fonts/fonts.less
+src/_common/sprites/sprites.less
 src/bundles.ts
 src/*/pages.ts
 src/resources.ts

--- a/solid-constants.config.js
+++ b/solid-constants.config.js
@@ -56,6 +56,9 @@ exports.atomsTypescriptFile = 'atoms.ts';
 // Fonts style file path
 exports.fontsStyleFile = 'fonts.less'
 
+// Sprites style file path
+exports.spritesStyleFile = 'sprites.less'
+
 // Default apps entry point
 exports.entryPoint = 'index.ts';
 

--- a/solid/task-fuse.js
+++ b/solid/task-fuse.js
@@ -675,8 +675,11 @@ const _preBuild = () =>
 	// Pre-build atoms typescript file
 	solidPreBuild.preBuildAtoms();
 
-	// Pre-build fonts list style file
+	// Pre-build fonts list import file
 	solidPreBuild.preBuildFonts();
+
+	// Pre-build sprites list import file
+	solidPreBuild.preBuildSprites();
 };
 
 

--- a/solid/task-prebuild.js
+++ b/solid/task-prebuild.js
@@ -298,7 +298,7 @@ module.exports = {
 		// For each sprites mixins files
 		spriteFiles.map( (FontFile) =>
 		{
-			// Do not follow Fonts.less
+			// Do not follow sprites.less
 			if (FontFile === `${spritesFolder}${solidConstants.spritesStyleFile}`) return;
 
 			// Extract bundle name from single bundle app path
@@ -315,7 +315,7 @@ module.exports = {
 			 * Auto-generated file, do not edit !
 			 * This file list all sprites mixins front sprites/ folder to import in the project.
 			 */
-			 ${ spritesFilesToImport.map( fontFile => `\n@import './${fontFile}';`).join('')}
+			 ${ spritesFilesToImport.map( spriteFile => `\n@import './${spriteFile}';`).join('')}
 			`).replace(fileTabRegex, "\n")
 
 		// Create new file

--- a/solid/task-prebuild.js
+++ b/solid/task-prebuild.js
@@ -232,7 +232,7 @@ module.exports = {
 	/**
 	 * Generate fonts less file
 	 *
-	 * This file contains all f
+	 * This file contains web-fonts less file import
 	 */
 	preBuildFonts: () =>
 	{
@@ -274,6 +274,55 @@ module.exports = {
 		Files.new(`${fontsFolder}${solidConstants.fontsStyleFile}`).write(
 			fontsTemplate()
 		)
+	},
+
+
+	/**
+	 * Generate sprites less file
+	 *
+	 * This file contains sprites less file import
+	 */
+	preBuildSprites: () =>
+	{
+		// Where sprites are stored
+		const spritesFolder = `${solidConstants.srcPath}${solidConstants.commonBundleName}/${solidConstants.spritesPath}`;
+
+		// All sprites files to import
+		let spritesFilesToImport = [];
+
+		// Get All sprites familiy files
+		let spriteFiles = Files.getFiles(`${spritesFolder}*.less`).files;
+
+		let spriteFileName = '';
+
+		// For each sprites mixins files
+		spriteFiles.map( (FontFile) =>
+		{
+			// Do not follow Fonts.less
+			if (FontFile === `${spritesFolder}${solidConstants.spritesStyleFile}`) return;
+
+			// Extract bundle name from single bundle app path
+			spriteFileName = `${path.basename(FontFile)}`;
+
+			// Push name in array
+			spritesFilesToImport.push(spriteFileName);
+		});
+
+		// Define template
+		const spritesTemplate = () => (`
+			/**
+			 * WARNING
+			 * Auto-generated file, do not edit !
+			 * This file list all sprites mixins front sprites/ folder to import in the project.
+			 */
+			 ${ spritesFilesToImport.map( fontFile => `\n@import './${fontFile}';`).join('')}
+			`).replace(fileTabRegex, "\n")
+
+		// Create new file
+		Files.new(`${spritesFolder}${solidConstants.spritesStyleFile}`).write(
+			spritesTemplate()
+		)
 	}
+
 
 };

--- a/solid/task-scaffold.js
+++ b/solid/task-scaffold.js
@@ -8,8 +8,8 @@ const changeCase = require('change-case');
 // Load solid constants
 const solidConstants = require('../solid-constants.config');
 
-// Load solid prebuild
-const solidPrebuild = require('./task-prebuild');
+// Load solid Pre-build
+const solidPreBuild = require('./task-prebuild');
 
 // ----------------------------------------------------------------------------- LOGS
 
@@ -359,9 +359,9 @@ const scaffolders = [
 			showInstructions([
 				`Add PNG images into ${ folderPath.bold } folder, named with ${ 'dash-case'.bold } convention.`,
 				`Sprite can be configured by editing ${ destinationConfigPath.bold } file.`,
-				`Launch ${ `node solid sprites`.bold } to generate less files.`,
-				`Import your sprite in ${ `${ bundlePath }Main.less`.bold } after a first ${ `node solid sprites`.bold }. `,
+				`Launch ${ `node solid sprites`.bold } to generate less files.`
 			]);
+
 		}
 	},
 
@@ -423,8 +423,8 @@ const scaffolders = [
 			// Show import instructions
 			showSuccess('Font face created!');
 
-			// Generate the new Fonts.less file including new font
-			solidPrebuild.preBuildFonts();
+			// Generate the new fonts.less file including new font import
+			solidPreBuild.preBuildFonts();
 		}
 	},
 

--- a/solid/task-sprites.js
+++ b/solid/task-sprites.js
@@ -7,6 +7,9 @@ const { optimizeFiles } = require('./task-imagemin');
 // Load solid constants
 const solidConstants = require('../solid-constants.config');
 
+// Load solid Pre-build
+const solidPreBuild = require('./task-prebuild');
+
 // ----------------------------------------------------------------------------- CONFIG
 
 // Sprite namming
@@ -254,6 +257,9 @@ module.exports = {
 					else if (--totalSprites === 0)
 					{
 						console.log(`  → Done !`.green);
+
+						// Generate the new sprites.less file including new import
+						solidPreBuild.preBuildSprites();
 
 						// Optimise images
 						Promise.all( optimizeImages() ).then( resolve );

--- a/src/_common/Main.less
+++ b/src/_common/Main.less
@@ -11,17 +11,18 @@
 @import (reference) './atoms/Properties.less';
 @import (reference) './atoms/Breakpoints.less';
 
-// Import Pre-build web-fonts file
+// Import Pre-build web-fonts import file
 @import './fonts/fonts.less';
+
+// Import Pre-build sprites import file
+// (import them as reference if you only need mixins)
+@import (reference) "sprites/sprites.less";
 
 // Import mixins, not as reference so you can add css declarations
 @import './mixins/Alignments.less';
 @import './mixins/Backgrounds.less';
 @import './mixins/Patches.less';
 @import './mixins/Texts.less';
-
-// Import sprites (import them as reference if you only need mixins)
-//@import (reference) "./sprites/sprite-main-interface.less";
 
 // Import layout styling
 @import './layout/Body.less';


### PR DESCRIPTION
Même fonctionnement que pour les fonts. 
Un Pre-build sprites file contenant les imports des sprites générés est créé à la racine du dossier [./src/_common/sprites](./src/_common/sprites). Ce pre-build est importé par défaut dans [./src/_common/Main.tsx](./src/_common/Main.tsx).